### PR TITLE
Update project structure.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,4 @@
+tmux rename-window network-uri-json
 watch_file network-uri-json.nix
 watch_file nix/*
-use_nix
+use_nix -p ar

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+.direnv/
+
 # Created by https://www.gitignore.io/api/haskell
+# Edit at https://www.gitignore.io/?templates=haskell
 
 ### Haskell ###
 dist
@@ -20,6 +23,8 @@ cabal.sandbox.config
 *.eventlog
 .stack-work/
 cabal.project.local
+cabal.project.local~
 .HTF/
+.ghc.environment.*
 
 # End of https://www.gitignore.io/api/haskell

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "network-uri-json";
-  version = "0.2.0.0";
+  version = "0.3.1.1";
   src = ./.;
   libraryHaskellDepends = [ aeson base network-uri text ];
   testHaskellDepends = [

--- a/network-uri-json.cabal
+++ b/network-uri-json.cabal
@@ -1,20 +1,27 @@
 name:                network-uri-json
 version:             0.3.1.1
-synopsis:            FromJSON and ToJSON Instances for Network.URI
 
-description:
-  FromJSON and ToJSON instances for Network.URI.
+license:             MIT
+license-file:        LICENSE
+
+copyright:           (c) 2017 Alex Brandt
+
+author:              Alex Brandt
+maintainer:          alunduil@alunduil.com
+
+stability:           stable
 
 homepage:            https://github.com/alunduil/network-uri-json
 bug-reports:         https://github.com/alunduil/network-uri-json/issues
-license:             MIT
-license-file:        LICENSE
-author:              Alex Brandt
-maintainer:          alunduil@alunduil.com
-copyright:           (c) 2017 Alex Brandt
+
+synopsis:            FromJSON and ToJSON Instances for Network.URI
+description:
+  FromJSON and ToJSON instances for Network.URI.
+
 category:            Network
-build-type:          Simple
+
 cabal-version:       >=1.10
+build-type:          Simple
 tested-with:         GHC >= 7.6 && < 7.8.1 || > 7.8.1 && < 8.2.1 || > 8.2.1 && < 9.0
 
 extra-source-files:
@@ -24,62 +31,74 @@ extra-source-files:
   , README.md
   , Setup.hs
 
-source-repository head
-  type:     git
-  location: https://github.com/alunduil/network-uri-json
-  branch:   develop
-
 library
+  ghc-options:
+    -Wall
+  if impl(ghc >= 8) {
+  ghc-options:
+    -Wcompat
+  } else {
+  ghc-options:
+    -fwarn-monomorphism-restriction
+    -fwarn-tabs
+    -fwarn-unused-do-bind
+  }
+
   default-language:    Haskell2010
 
-  ghc-options: -Wall -fwarn-tabs -fwarn-monomorphism-restriction
-               -fwarn-unused-do-bind
-
-  hs-source-dirs:
-      src
+  build-depends:
+      aeson >= 0.8 && < 1.5
+    , base >= 4.6 && < 4.14
+    , network-uri >= 2.6 && < 2.8
+    , text == 1.2.*
 
   exposed-modules:
       Network.URI.JSON
 
   other-modules:
 
-  build-depends:
-      aeson       >= 0.8 && < 1.5
-    , base        >= 4.6 && < 4.14
-    , network-uri >= 2.6 && < 2.8
-    , text        == 1.2.*
-
-  other-extensions:
-      OverloadedStrings
+  hs-source-dirs:
+      src
 
 test-suite network-uri-json-tests
-  default-language: Haskell2010
   type:             exitcode-stdio-1.0
   main-is:          Spec.hs
 
-  ghc-options: -Wall -fwarn-tabs -fwarn-monomorphism-restriction
-               -fwarn-unused-do-bind
+  ghc-options:
+    -Wall
+  if impl(ghc >= 8) {
+  ghc-options:
+    -Wcompat
+  } else {
+  ghc-options:
+    -fwarn-monomorphism-restriction
+    -fwarn-tabs
+    -fwarn-unused-do-bind
+  }
 
-  hs-source-dirs:
-      src
-    , test
+  default-language: Haskell2010
+
+  build-depends:
+      aeson >= 0.8 && < 1.5
+    , base >= 4.6 && < 4.14
+    , hspec >= 2.4 && < 2.8
+    , network-arbitrary >= 0.3 && < 0.7
+    , network-uri >= 2.6 && < 2.8
+    , test-invariant == 0.4.*
+    , text == 1.2.*
 
   other-modules:
       Network.URI.JSON
     , Network.URI.JSONSpec
 
+  hs-source-dirs:
+      src
+    , test
+
   build-tool-depends:
       hspec-discover:hspec-discover >= 2.4 && < 2.8
 
-  build-depends:
-      aeson             >= 0.8 && < 1.5
-    , base              >= 4.6 && < 4.14
-    , hspec             >= 2.4 && < 2.8
-    , network-arbitrary >= 0.3 && < 0.7
-    , network-uri       >= 2.6 && < 2.8
-    , test-invariant    == 0.4.*
-    , text              == 1.2.*
-
-  other-extensions:
-      OverloadedStrings
-    , RecordWildCards
+source-repository head
+  type:     git
+  location: https://github.com/alunduil/network-uri-json
+  branch:   develop

--- a/nix/network-arbitrary.nix
+++ b/nix/network-arbitrary.nix
@@ -4,8 +4,8 @@
 }:
 mkDerivation {
   pname = "network-arbitrary";
-  version = "0.4.0.1";
-  sha256 = "697e918907f3946edadd30246c041fe4c5d77f24d47eb5d165565091df303498";
+  version = "0.6.0.0";
+  sha256 = "01d60abb580b3eda290678d88a253ed4ad80d57cfcac4e27e46e59724f1e497a";
   libraryHaskellDepends = [
     base bytestring http-media http-types network-uri QuickCheck
   ];

--- a/src/Network/URI/JSON.hs
+++ b/src/Network/URI/JSON.hs
@@ -12,12 +12,22 @@ URI Instances for FromJSON and ToJSON
 -}
 module Network.URI.JSON where
 
-import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), withText)
-import Data.Text (unpack)
-import Network.URI (parseURIReference, URI, uriToString)
+import           Data.Aeson                     ( FromJSON(parseJSON)
+                                                , ToJSON(toJSON)
+                                                , withText
+                                                )
+import           Data.Text                      ( unpack )
+import           Network.URI                    ( parseURIReference
+                                                , URI
+                                                , uriToString
+                                                )
 
 instance FromJSON URI where
-  parseJSON = withText "URI" $ maybe (fail "invalid URI") return . parseURIReference . unpack
+  parseJSON =
+    withText "URI"
+      $ maybe (fail "invalid URI") return
+      . parseURIReference
+      . unpack
 
 instance ToJSON URI where
   toJSON u = toJSON $ uriToString id u ""

--- a/test/Network/URI/JSONSpec.hs
+++ b/test/Network/URI/JSONSpec.hs
@@ -6,22 +6,31 @@ License     : MIT
 
 Tests for "Network.URI.JSON".
 -}
-module Network.URI.JSONSpec (main, spec) where
+module Network.URI.JSONSpec
+  ( main
+  , spec
+  )
+where
 
-import Data.Aeson (decode, encode)
-import Data.Maybe (fromJust)
-import Network.URI.Arbitrary ()
-import Network.URI (URI)
-import Test.Hspec (describe, hspec, Spec)
-import Test.Hspec.QuickCheck (prop)
-import Test.Invariant ((<=>))
+import           Data.Aeson                     ( decode
+                                                , encode
+                                                )
+import           Data.Maybe                     ( fromJust )
+import           Network.URI.Arbitrary          ( )
+import           Network.URI                    ( URI )
+import           Test.Hspec                     ( describe
+                                                , hspec
+                                                , Spec
+                                                )
+import           Test.Hspec.QuickCheck          ( prop )
+import           Test.Invariant                 ( (<=>) )
 
-import Network.URI.JSON ()
+import           Network.URI.JSON               ( )
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
-spec =
-  describe "properties" $
-    prop "fromJust . decode . encode == id" (fromJust . decode . encode <=> id :: URI -> Bool)
+spec = describe "properties" $ prop
+  "fromJust . decode . encode == id"
+  (fromJust . decode . encode <=> id :: URI -> Bool)


### PR DESCRIPTION
This changes the cabal file layout slightly.  We use a nix derivation of
network-arbitrary-0.6.0.0.  We also use brittany to format the source
code.  The last update is an updated gitignore file.

This is just to keep the project structure up to date with other new
projects I've been toying with.