### PR TITLE
release 0.4.0.0 (develop)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Revision history for network-uri-json
 
+## 0.4.0.0
+
+* Update project structure.
+* Fixing cabal outdated
+* Exclude GHC 7.8.1
+* Revert tested-with. Regenerate travis.yaml
+* Update network-arbitraty version. Update tested-with
+* Make compatible with GHC 8.8
+
 ## 0.3.1.1  -- 2019-02-21
 
 * Update cabal.config for cloudbuild.

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "network-uri-json";
-  version = "0.3.1.1";
+  version = "0.4.0.0";
   src = ./.;
   libraryHaskellDepends = [ aeson base network-uri text ];
   testHaskellDepends = [

--- a/network-uri-json.cabal
+++ b/network-uri-json.cabal
@@ -1,5 +1,5 @@
 name:                network-uri-json
-version:             0.3.1.1
+version:             0.4.0.0
 
 license:             MIT
 license-file:        LICENSE
@@ -7,7 +7,7 @@ license-file:        LICENSE
 copyright:           (c) 2017 Alex Brandt
 
 author:              Alex Brandt
-maintainer:          alunduil@alunduil.com
+maintainer:          alunduil@gmail.com
 
 stability:           stable
 


### PR DESCRIPTION
* Update project structure.
* Fixing cabal outdated
* Exclude GHC 7.8.1
* Revert tested-with. Regenerate travis.yaml
* Update network-arbitraty version. Update tested-with
* Make compatible with GHC 8.8