### PR TITLE
chore(cabal): widen text bound to >=1.2 && <3

### DIFF
--- a/network-uri-json.cabal
+++ b/network-uri-json.cabal
@@ -50,7 +50,7 @@ library
       aeson >=0.8 && <2.3
     , base >=4.6 && <4.23
     , network-uri >= 2.6 && < 2.8
-    , text == 1.2.*
+    , text >=1.2 && <3
 
   exposed-modules:
       Network.URI.JSON
@@ -85,7 +85,7 @@ test-suite network-uri-json-tests
     , network-arbitrary >=0.3 && <1.1
     , network-uri >= 2.6 && < 2.8
     , test-invariant == 0.4.*
-    , text == 1.2.*
+    , text >=1.2 && <3
 
   other-modules:
       Network.URI.JSON


### PR DESCRIPTION
## Summary

The package now solves against `text-2.x` shipped with GHC 9.6+, removing the constraint solver failure caused by the previous `text == 1.2.*` pin.

## Verification

- Confirmed `src/Network/URI/JSON.hs` only imports `Data.Text.unpack`, which is stable across text-1.2 and text-2.x — no source changes needed.
- Cross-version build verification deferred to the GHC matrix CI work in #64.

Closes #57