### PR TITLE
docs(readme): document cabal commands and drop Travis references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
 # Description
 
+[![CI](https://github.com/alunduil/network-uri-json/actions/workflows/ci.yml/badge.svg)](https://github.com/alunduil/network-uri-json/actions/workflows/ci.yml)
+
 [FromJSON] and [ToJSON] Instances for [Network.URI][network-uri]
 
 # Getting Started
 
 Documentation is available on [Hackage].  A beginner's guide to
 [Data.Aeson][aeson] is <https://artyom.me/aeson>.
+
+# Building
+
+Build, test, and generate Haddock documentation with [cabal]:
+
+```
+cabal build
+cabal test
+cabal haddock
+```
 
 # Reporting Issues
 
@@ -14,8 +26,7 @@ you've found an error or have a suggestion for a new feature; please, ensure
 that it is reported.
 
 If you would like to contribute a fix or new feature; please, submit a pull
-request.  This project follows [git flow] and utilizes [travis] to automatically
-check pull requests before a manual review.
+request.
 
 # Contributors
 
@@ -24,11 +35,10 @@ copyrights and other information.  If you submit a pull request and would like
 attribution; please, add yourself to the `COPYRIGHT` file.
 
 [aeson]: https://hackage.haskell.org/package/aeson
+[cabal]: https://www.haskell.org/cabal/
 [FromJSON]: https://hackage.haskell.org/package/aeson/docs/Data-Aeson.html#t:FromJSON
-[git flow]: http://nvie.com/posts/a-successful-git-branching-model/
 [Hackage]: https://hackage.haskell.org/package/network-uri-json
 [Haskell]: https://www.haskell.org/
 [issues]: https://github.com/alunduil/network-uri-json/issues
 [network-uri]: https://hackage.haskell.org/package/network-uri
 [ToJSON]: https://hackage.haskell.org/package/aeson/docs/Data-Aeson.html#t:ToJSON
-[travis]: https://travis-ci.org/alunduil/network-uri-json


### PR DESCRIPTION
## Summary

README now documents `cabal build`, `cabal test`, and `cabal haddock` so contributors can find the real development commands. Travis prose and the dead `[travis]` link reference are gone, and a GitHub Actions CI badge sits in their place.

## Gotchas

- The CI badge points at `actions/workflows/ci.yml`, which doesn't exist yet — it will resolve once #64 (handwritten GHA matrix) lands. Until then it renders as "no status," which seemed preferable to a dangling Travis link.
- No Cloud Build references existed in the README to remove (the issue body anticipated some); `cloudbuild.yaml` itself is retired separately under #75 / PR #94.
- Richer badge work (Hackage, matrix) is out of scope here and tracked under #82.

Closes #47