### PR TITLE
docs(ai): add AGENTS.md and CLAUDE.md import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # AGENTS.md
 
-Repo conventions for AI agents working on `network-uri-json`. Repo-specific
-only; does not duplicate user-level or general Haskell guidance.
+Repo conventions for AI coding agents working on `network-uri-json`.
+Repo-specific only — does not duplicate user-level or general Haskell
+guidance.
 
 ## What this is
 
@@ -9,65 +10,79 @@ A small library: `FromJSON`/`ToJSON` instances for `Network.URI.URI`. One
 public module (`src/Network/URI/JSON.hs`), one hspec suite
 (`test/Network/URI/JSONSpec.hs`). The interesting work happens in tests.
 
-## Commands
+## Setup & commands
 
 - `cabal build` — compile library and tests.
 - `cabal test` — run the hspec suite.
 - `cabal haddock` — render Haddock for the library.
 
-Lint and format tooling (ormolu, hlint, `cabal check`, `cabal-gild`) is being
-introduced under milestone 0.4.0.2 — see #60, #61, #65, #68. Until those
-land, don't introduce a competing formatter or lint config.
+GHC versions exercised: see `tested-with` in `network-uri-json.cabal`.
+The cabal file still uses `cabal-version: >=1.10` syntax; that flips
+to `3.0` under #56.
 
-## Invariants
+## Code style
 
-- **PVP versioning** (<https://pvp.haskell.org>). Major bumps for breaking
-  changes, minor for additive, patch for non-API. The
-  conventional-commits → PVP mapping is being formalised in #80.
-- **Property-test coverage.** Tests use `hspec` + `network-arbitrary`
-  (URI generators) + `test-invariant`. The existing round-trip property
-  (`fromJust . decode . encode <=> id`) is the template — new behaviour
-  should ship with a property where the law makes sense (round-trip,
-  idempotence). Property roadmap: #67.
-- **No partial functions in library code.** `src/Network/URI/JSON.hs` uses
-  `withText` + `maybe ... fail` for parse failure; match that. `fromJust`
-  is acceptable in test scaffolding only because failure surfaces as a
-  test failure.
-- **Orphans confined to `Network.URI.JSON`.** This module exists to hold
-  the orphan instances for `URI`. Don't reintroduce orphans elsewhere.
+- **Orphans confined to `Network.URI.JSON`.** This module exists to
+  hold the orphan instances for `URI`. Don't reintroduce orphans
+  elsewhere or split the module.
+- **No partial functions in library code.** `src/Network/URI/JSON.hs`
+  uses `withText` + `maybe ... fail` for parse failure — match that.
+  `fromJust` / `head` / `error` are acceptable in test scaffolding
+  only, because failure surfaces as a test failure.
+- **Formatter.** Ormolu adoption is in flight (#60). Until it lands,
+  match the surrounding style; don't introduce a competing formatter
+  or reformat unrelated code in passing.
+
+## Testing
+
+- Stack: `hspec` + `hspec-discover` + `network-arbitrary` (URI
+  generators) + `test-invariant` (`<=>` for invariant laws).
+- The existing round-trip property `fromJust . decode . encode <=> id`
+  is the template — new behaviour should ship with a property where
+  the law makes sense (round-trip, idempotence, etc.). Property
+  roadmap: #67.
+- Don't test upstream behaviour (aeson decoding, `network-uri`
+  parsing). Project tests cover this library's instances and
+  invariants only.
+
+## Pull requests
+
+- **Trunk-based.** Branch from `develop` today; the default flips to
+  `main` under #70.
+- **Conventional commits.** `feat:` / `fix:` / `chore:` / `docs:` /
+  `ci:` / `test:` / `refactor:`. Imperative subject ≤50 chars, blank
+  line, wrapped body when context is needed.
+- **PVP versioning** (<https://pvp.haskell.org>). Working mapping
+  until #80 formalises it:
+  - `feat!:` / `BREAKING CHANGE:` — A.B bump (major)
+  - `feat:` adding to the public API — C bump (minor)
+  - `fix:` or non-API change — D bump (patch)
+  - non-user-visible (`chore:`, `ci:`, `test:`, `docs:`) — no bump
+- **Draft PRs by default.** Maintainer promotes to ready after review.
+- **Squash merge, linear history** (#71). Don't worry about
+  commit-by-commit cleanliness; the squash collapses noise.
 
 ## Don't touch
 
 - **`text` bound** stays `>=1.2 && <3` (#93). Don't tighten the lower
   bound — older Stackage LTS series are still in scope.
-- **`network-uri` bound** stays `>=2.6 && <2.8` until upstream ships 2.8.
-  Bumping requires a PVP-aware bound bump, not a silent upgrade.
+- **`network-uri` bound** stays `>=2.6 && <2.8` until upstream ships
+  2.8. Bumping requires a PVP-aware bound bump, not a silent upgrade.
 - **`aeson` bound** spans 1.x and 2.x; both must keep building.
 - **Public API.** `stability: stable` in the cabal file. Removing or
   renaming exports is a major bump and needs explicit user direction;
   additive changes are tracked in #62.
-- **Nix files** (`default.nix`, `shell.nix`, `network-uri-json.nix`,
-  `nix/`, `.envrc`) are slated for removal alongside devcontainer
-  adoption — decision recorded in #89. Don't update them; cite the
-  retirement issue if they need to change.
-- **`source-repository` `branch:` field** in the cabal file currently
-  reads `develop`; it flips to `main` under #70. Don't update it ahead
-  of that issue.
+- **In-flight modernization artefacts.** `default.nix`, `shell.nix`,
+  `network-uri-json.nix`, `nix/`, `.envrc`, and the cabal
+  `source-repository`'s `branch: develop` field are all queued for
+  removal or update. Don't update them in passing; cite the relevant
+  issue under #89 instead.
 
-## Modernization in flight
+## Modernization status
 
-The repo is mid-modernization — see #89 (master tracker) before assuming
-state matches the `network-arbitrary` template. Notably absent today:
-`.github/workflows/`, `.devcontainer/`, `.pre-commit-config.yaml`,
-`cabal-version: 3.0` syntax, `main` as the default branch. Each is its
-own issue under milestones 0.4.0.1–0.4.0.3.
-
-## Layout
-
-- `src/Network/URI/JSON.hs` — the entire library.
-- `test/Spec.hs`, `test/Network/URI/JSONSpec.hs` — hspec suite.
-- `network-uri-json.cabal` — package description (still `>=1.10`
-  syntax until #56).
-- `ChangeLog.md` — release notes; Keep a Changelog adoption tracked
-  separately.
-- `README.md` — public-facing.
+This repo is mid-modernization toward the `network-arbitrary`
+template. State that doesn't match the template
+(no `.github/workflows`, no `.devcontainer`, `cabal-version: >=1.10`,
+default branch `develop`) is intentional and tracked. **Master tracker:
+#89** — read it before assuming a missing piece is an oversight rather
+than a queued issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,88 +1,64 @@
 # AGENTS.md
 
-Repo conventions for AI coding agents working on `network-uri-json`.
-Repo-specific only — does not duplicate user-level or general Haskell
-guidance.
+## Setup
 
-## What this is
-
-A small library: `FromJSON`/`ToJSON` instances for `Network.URI.URI`. One
-public module (`src/Network/URI/JSON.hs`), one hspec suite
-(`test/Network/URI/JSONSpec.hs`). The interesting work happens in tests.
-
-## Setup & commands
-
-- `cabal build` — compile library and tests.
-- `cabal test` — run the hspec suite.
-- `cabal haddock` — render Haddock for the library.
-
-GHC versions exercised: see `tested-with` in `network-uri-json.cabal`.
-The cabal file still uses `cabal-version: >=1.10` syntax; that flips
-to `3.0` under #56.
+- `cabal build`
+- `cabal test`
+- `cabal haddock`
 
 ## Code style
 
-- **Orphans confined to `Network.URI.JSON`.** This module exists to
-  hold the orphan instances for `URI`. Don't reintroduce orphans
-  elsewhere or split the module.
-- **No partial functions in library code.** `src/Network/URI/JSON.hs`
-  uses `withText` + `maybe ... fail` for parse failure — match that.
-  `fromJust` / `head` / `error` are acceptable in test scaffolding
-  only, because failure surfaces as a test failure.
-- **Formatter.** Ormolu adoption is in flight (#60). Until it lands,
-  match the surrounding style; don't introduce a competing formatter
-  or reformat unrelated code in passing.
+- Orphan instances for `URI` live in `Network.URI.JSON`. Don't
+  reintroduce orphans elsewhere or split the module.
+- Library code: no partial functions. `src/Network/URI/JSON.hs` uses
+  `withText` + `maybe ... fail` for parse failure — match that
+  pattern. `fromJust` / `head` / `error` are acceptable only in test
+  scaffolding, where failure surfaces as a test failure.
+- Formatter: ormolu adoption is in flight (#60). Until it lands,
+  match surrounding style; don't introduce a competing formatter or
+  reformat unrelated code in passing.
 
 ## Testing
 
-- Stack: `hspec` + `hspec-discover` + `network-arbitrary` (URI
-  generators) + `test-invariant` (`<=>` for invariant laws).
-- The existing round-trip property `fromJust . decode . encode <=> id`
-  is the template — new behaviour should ship with a property where
-  the law makes sense (round-trip, idempotence, etc.). Property
-  roadmap: #67.
+- `network-arbitrary` supplies `URI` generators; `test-invariant`
+  supplies `<=>` for invariant laws.
+- The round-trip property `fromJust . decode . encode <=> id` in
+  `test/Network/URI/JSONSpec.hs` is the template — new behaviour
+  should ship with a property where the law makes sense (round-trip,
+  idempotence). Property roadmap: #67.
 - Don't test upstream behaviour (aeson decoding, `network-uri`
-  parsing). Project tests cover this library's instances and
-  invariants only.
+  parsing). Project tests cover this library's instances only.
 
 ## Pull requests
 
-- **Trunk-based.** Branch from `develop` today; the default flips to
-  `main` under #70.
-- **Conventional commits.** `feat:` / `fix:` / `chore:` / `docs:` /
-  `ci:` / `test:` / `refactor:`. Imperative subject ≤50 chars, blank
-  line, wrapped body when context is needed.
-- **PVP versioning** (<https://pvp.haskell.org>). Working mapping
-  until #80 formalises it:
-  - `feat!:` / `BREAKING CHANGE:` — A.B bump (major)
-  - `feat:` adding to the public API — C bump (minor)
-  - `fix:` or non-API change — D bump (patch)
-  - non-user-visible (`chore:`, `ci:`, `test:`, `docs:`) — no bump
-- **Draft PRs by default.** Maintainer promotes to ready after review.
-- **Squash merge, linear history** (#71). Don't worry about
-  commit-by-commit cleanliness; the squash collapses noise.
+- Branch from `develop` today; default flips to `main` under #70.
+- Conventional commits, imperative subject ≤50 chars.
+- PVP bumps (<https://pvp.haskell.org>) — working mapping until #80
+  formalises it:
+  - `feat!:` / `BREAKING CHANGE:` → A.B (major)
+  - `feat:` adding public API → C (minor)
+  - `fix:` or non-API change → D (patch)
+  - `chore:` / `ci:` / `test:` / `docs:` → no bump
+- Draft PRs by default; maintainer promotes after review.
+- Squash merge, linear history (#71).
 
 ## Don't touch
 
-- **`text` bound** stays `>=1.2 && <3` (#93). Don't tighten the lower
-  bound — older Stackage LTS series are still in scope.
-- **`network-uri` bound** stays `>=2.6 && <2.8` until upstream ships
-  2.8. Bumping requires a PVP-aware bound bump, not a silent upgrade.
-- **`aeson` bound** spans 1.x and 2.x; both must keep building.
-- **Public API.** `stability: stable` in the cabal file. Removing or
-  renaming exports is a major bump and needs explicit user direction;
-  additive changes are tracked in #62.
-- **In-flight modernization artefacts.** `default.nix`, `shell.nix`,
-  `network-uri-json.nix`, `nix/`, `.envrc`, and the cabal
-  `source-repository`'s `branch: develop` field are all queued for
-  removal or update. Don't update them in passing; cite the relevant
-  issue under #89 instead.
+- `text` bound stays `>=1.2 && <3` (#93) — older Stackage LTS series
+  are still in scope.
+- `network-uri` bound stays `>=2.6 && <2.8` until upstream ships 2.8.
+- `aeson` bound spans 1.x and 2.x; both must keep building.
+- Public API is `stability: stable`. Removing or renaming exports is
+  a major bump and needs explicit direction; additive changes are
+  tracked in #62.
+- `default.nix`, `shell.nix`, `network-uri-json.nix`, `nix/`, `.envrc`,
+  and the cabal `source-repository`'s `branch: develop` field are all
+  queued for removal or update. Don't update in passing; cite the
+  relevant issue under #89.
 
 ## Modernization status
 
-This repo is mid-modernization toward the `network-arbitrary`
-template. State that doesn't match the template
-(no `.github/workflows`, no `.devcontainer`, `cabal-version: >=1.10`,
-default branch `develop`) is intentional and tracked. **Master tracker:
-#89** — read it before assuming a missing piece is an oversight rather
-than a queued issue.
+Mid-modernization toward the `network-arbitrary` template. Missing
+`.github/workflows`, `.devcontainer`, `cabal-version: 3.0`, and `main`
+as the default branch — all tracked under #89. Read the tracker
+before treating a gap as an oversight.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md
+
+Repo conventions for AI agents working on `network-uri-json`. Repo-specific
+only; does not duplicate user-level or general Haskell guidance.
+
+## What this is
+
+A small library: `FromJSON`/`ToJSON` instances for `Network.URI.URI`. One
+public module (`src/Network/URI/JSON.hs`), one hspec suite
+(`test/Network/URI/JSONSpec.hs`). The interesting work happens in tests.
+
+## Commands
+
+- `cabal build` — compile library and tests.
+- `cabal test` — run the hspec suite.
+- `cabal haddock` — render Haddock for the library.
+
+Lint and format tooling (ormolu, hlint, `cabal check`, `cabal-gild`) is being
+introduced under milestone 0.4.0.2 — see #60, #61, #65, #68. Until those
+land, don't introduce a competing formatter or lint config.
+
+## Invariants
+
+- **PVP versioning** (<https://pvp.haskell.org>). Major bumps for breaking
+  changes, minor for additive, patch for non-API. The
+  conventional-commits → PVP mapping is being formalised in #80.
+- **Property-test coverage.** Tests use `hspec` + `network-arbitrary`
+  (URI generators) + `test-invariant`. The existing round-trip property
+  (`fromJust . decode . encode <=> id`) is the template — new behaviour
+  should ship with a property where the law makes sense (round-trip,
+  idempotence). Property roadmap: #67.
+- **No partial functions in library code.** `src/Network/URI/JSON.hs` uses
+  `withText` + `maybe ... fail` for parse failure; match that. `fromJust`
+  is acceptable in test scaffolding only because failure surfaces as a
+  test failure.
+- **Orphans confined to `Network.URI.JSON`.** This module exists to hold
+  the orphan instances for `URI`. Don't reintroduce orphans elsewhere.
+
+## Don't touch
+
+- **`text` bound** stays `>=1.2 && <3` (#93). Don't tighten the lower
+  bound — older Stackage LTS series are still in scope.
+- **`network-uri` bound** stays `>=2.6 && <2.8` until upstream ships 2.8.
+  Bumping requires a PVP-aware bound bump, not a silent upgrade.
+- **`aeson` bound** spans 1.x and 2.x; both must keep building.
+- **Public API.** `stability: stable` in the cabal file. Removing or
+  renaming exports is a major bump and needs explicit user direction;
+  additive changes are tracked in #62.
+- **Nix files** (`default.nix`, `shell.nix`, `network-uri-json.nix`,
+  `nix/`, `.envrc`) are slated for removal alongside devcontainer
+  adoption — decision recorded in #89. Don't update them; cite the
+  retirement issue if they need to change.
+- **`source-repository` `branch:` field** in the cabal file currently
+  reads `develop`; it flips to `main` under #70. Don't update it ahead
+  of that issue.
+
+## Modernization in flight
+
+The repo is mid-modernization — see #89 (master tracker) before assuming
+state matches the `network-arbitrary` template. Notably absent today:
+`.github/workflows/`, `.devcontainer/`, `.pre-commit-config.yaml`,
+`cabal-version: 3.0` syntax, `main` as the default branch. Each is its
+own issue under milestones 0.4.0.1–0.4.0.3.
+
+## Layout
+
+- `src/Network/URI/JSON.hs` — the entire library.
+- `test/Spec.hs`, `test/Network/URI/JSONSpec.hs` — hspec suite.
+- `network-uri-json.cabal` — package description (still `>=1.10`
+  syntax until #56).
+- `ChangeLog.md` — release notes; Keep a Changelog adoption tracked
+  separately.
+- `README.md` — public-facing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,1 @@
-# Claude Code instructions
-
-See [`AGENTS.md`](AGENTS.md) for repo conventions, commands,
-invariants, and the don't-touch list. The line below imports it into
-Claude Code's context so both Claude Code and `AGENTS.md`-aware tools
-(Codex, Cursor, Aider, Copilot Coding Agent, etc.) read the same
-source of truth.
-
 @AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Claude Code instructions
+
+See [`AGENTS.md`](AGENTS.md) for repo conventions, commands,
+invariants, and the don't-touch list. The line below imports it into
+Claude Code's context so both Claude Code and `AGENTS.md`-aware tools
+(Codex, Cursor, Aider, Copilot Coding Agent, etc.) read the same
+source of truth.
+
+@AGENTS.md


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` as the single source of truth for AI-agent repo conventions, and a one-line `CLAUDE.md` (`@AGENTS.md`) so Claude Code — which doesn't read `AGENTS.md` natively, per [Anthropic's memory docs](https://code.claude.com/docs/en/memory.md) — picks it up today. Closes #49 and #87.

`AGENTS.md` is scoped to non-discoverable content only: orphan-confinement, no-partial-functions in library code, ormolu-pending formatter status, the round-trip property template, "don't test upstream", PR conventions (conventional-commits → PVP mapping, draft + squash-merge norms), bound pins (`text`, `network-uri`, `aeson`) with their *whys*, and a modernization-tracker pointer at #89. Project description, file layout, dependency listing, and cabal-version state were trimmed out — they're recoverable from `network-uri-json.cabal` and the README.

## Gotchas

- `CLAUDE.md` is one line: `@AGENTS.md`. The import is the documented Anthropic interop pattern; a symlink would also work but breaks on Windows, matching the call already made in #87.
- Issue references in "Don't touch" and "Modernization status" are scoped to rules that should fall out as those issues close. The durable pointer is #89.
- `.github/copilot-instructions.md` (#85) stays separate — it depends on the `.github/` directory landing under milestone 0.4.0.2.

## Verification

- Confirmed claims against the tree: `withText` + `maybe ... fail` in `src/Network/URI/JSON.hs`; `fromJust . decode . encode <=> id` in `test/Network/URI/JSONSpec.hs`; `stability: stable` and the three bounds in `network-uri-json.cabal`.
- Cross-checked every \`#NN\` reference against #89: #56, #60, #62, #67, #70, #71, #80, #87, #89, #93 all resolve to issues in the role described.
- Cross-referenced the AGENTS.md / CLAUDE.md interop convention against [code.claude.com/docs/en/memory.md](https://code.claude.com/docs/en/memory.md), [agents.md](https://agents.md/), and the December 2025 [Linux Foundation AAIF announcement](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation).