### PR TITLE
chore(branch): point cabal source-repository at main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,6 @@
 
 ## Pull requests
 
-- Branch from `develop` today; default flips to `main` under #70.
 - Conventional commits, imperative subject ≤50 chars.
 - PVP bumps (<https://pvp.haskell.org>) — working mapping until #80
   formalises it:
@@ -51,14 +50,13 @@
 - Public API is `stability: stable`. Removing or renaming exports is
   a major bump and needs explicit direction; additive changes are
   tracked in #62.
-- `default.nix`, `shell.nix`, `network-uri-json.nix`, `nix/`, `.envrc`,
-  and the cabal `source-repository`'s `branch: develop` field are all
-  queued for removal or update. Don't update in passing; cite the
-  relevant issue under #89.
+- `default.nix`, `shell.nix`, `network-uri-json.nix`, `nix/`, and
+  `.envrc` are queued for removal or update. Don't update in passing;
+  cite the relevant issue under #89.
 
 ## Modernization status
 
 Mid-modernization toward the `network-arbitrary` template. Missing
-`.github/workflows`, `.devcontainer`, `cabal-version: 3.0`, and `main`
-as the default branch — all tracked under #89. Read the tracker
-before treating a gap as an oversight.
+`.github/workflows`, `.devcontainer`, and `cabal-version: 3.0` — all
+tracked under #89. Read the tracker before treating a gap as an
+oversight.

--- a/network-uri-json.cabal
+++ b/network-uri-json.cabal
@@ -101,4 +101,4 @@ test-suite network-uri-json-tests
 source-repository head
   type:     git
   location: https://github.com/alunduil/network-uri-json
-  branch:   develop
+  branch:   main


### PR DESCRIPTION
## Summary

In-repo half of the trunk-rename: cabal `source-repository`'s
`branch` field flips from `develop` to `main`, and AGENTS.md
loses the transitional bullets that referenced the pre-rename
state.

## Gotchas

- The remote rename (merge `develop` → `master`, rename `master`
  → `main`, set default, delete `develop`, apply protection) is
  a separate post-merge admin step — not in this diff.
- `cabal build` currently fails on `develop` regardless of this
  PR: aeson 2.2.4.1 now provides its own `FromJSON`/`ToJSON URI`
  instances, colliding with this library's orphans. Pre-existing
  upstream collision, worth filing separately under #89.

## Verification

- `git stash && cabal build` reproduces the orphan collision
  failure on bare `develop`, confirming this PR doesn't
  introduce it.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)