### PR TITLE
chore(cabal): narrow GHC matrix and base bound

### DIFF
--- a/network-uri-json.cabal
+++ b/network-uri-json.cabal
@@ -20,9 +20,9 @@ description:
 
 category:            Network
 
-cabal-version:       >=1.10
+cabal-version:       2.0
 build-type:          Simple
-tested-with:         GHC >= 7.6 && < 7.8.1 || > 7.8.1 && < 8.2.1 || > 8.2.1 && < 9.0
+tested-with:         GHC == 9.6.* || == 9.8.* || == 9.10.* || == 9.12.* || == 9.14.*
 
 extra-source-files:
     ChangeLog.md
@@ -48,7 +48,7 @@ library
 
   build-depends:
       aeson >=0.8 && <2.3
-    , base >=4.6 && <4.23
+    , base ^>=4.18 || ^>=4.19 || ^>=4.20 || ^>=4.21 || ^>=4.22
     , network-uri >= 2.6 && < 2.8
     , text >=1.2 && <3
 
@@ -80,7 +80,7 @@ test-suite network-uri-json-tests
 
   build-depends:
       aeson >=0.8 && <2.3
-    , base >=4.6 && <4.23
+    , base ^>=4.18 || ^>=4.19 || ^>=4.20 || ^>=4.21 || ^>=4.22
     , hspec >=2.4 && <2.12
     , network-arbitrary >=0.3 && <1.1
     , network-uri >= 2.6 && < 2.8


### PR DESCRIPTION
## Summary

Narrows supported compilers and base bound to the current ghcup stable
set (GHC 9.6/9.8/9.10/9.12/9.14, base 4.18-4.22), and bumps
`cabal-version` to 2.0 so the `^>=` operator is valid in the new base
bound.

Closes #58. Decision recorded in #89.

## Gotchas

- `cabal-version` bumped 1.10 → 2.0 — the minimum that admits `^>=`.
  The eventual 3.0 bump (with common stanzas) remains #56.
- `cabal build` still fails on `develop` with duplicate `FromJSON URI`
  / `ToJSON URI` instances from aeson 2.2+. That's pre-existing and
  tracked in #95; this PR doesn't touch it.

## Verification

- `cabal check`: no new warnings introduced. Two pre-existing warnings
  remain (inconsistent indentation around `if impl(ghc >= 8)` blocks,
  `ChangeLog.md` placement in `extra-source-files`).
- Build/test parity with `develop`: confirmed the duplicate-instance
  failure reproduces unchanged via `git stash && cabal build`.