### PR TITLE
ci: add dependency-review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v2


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependency-review.yml`, mirroring the substrate from `alunduil/network-arbitrary`. PRs now run `actions/dependency-review-action` on the dependency diff, flagging known-vulnerable versions as a cheap security baseline.

## Gotchas

Action pins (`actions/checkout@v3`, `actions/dependency-review-action@v2`) match network-arbitrary verbatim so the four-repo policy has a single source of truth. Renovate will lift them across repos once #69 lands.

Closes #91.