### PR TITLE
docs(ai): orient agents and drop stale develop reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ orphans confined to `Network.URI.JSON`.
 
 ## Pull requests
 
-- Branch from `develop` today; default flips to `main` under #70.
+- Branch from `main`.
 - Conventional commits, imperative subject ≤50 chars.
 - PVP bumps (<https://pvp.haskell.org>) — working mapping until #80
   formalises it:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # AGENTS.md
 
+aeson `FromJSON`/`ToJSON` instances for `Network.URI.URI`, with
+orphans confined to `Network.URI.JSON`.
+
 ## Setup
 
 - `cabal build`


### PR DESCRIPTION
## Summary

One-line project orientation at the top of AGENTS.md — agents on first contact see what the library does without reading the cabal file or README.

Closes #87 (PR #97's `Closes #49 and #87` only parsed #49; this PR finishes the close).

## Gotchas

The orientation line reverses a deliberate trim from PR #97 ("recoverable from cabal+README"). The reversal is one line for a payoff on every session start.

## Verification

Cross-checked the orientation phrasing against `network-uri-json.cabal`'s `synopsis` and `src/Network/URI/JSON.hs` instance declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)