### PR TITLE
docs: deprecate in favour of aeson built-in URI instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 [![CI](https://github.com/alunduil/network-uri-json/actions/workflows/ci.yml/badge.svg)](https://github.com/alunduil/network-uri-json/actions/workflows/ci.yml)
 
+> **Deprecated — use [aeson] instead.** Since aeson 2.2.0.0 (2023),
+> aeson ships `FromJSON`/`ToJSON` (and `FromJSONKey`/`ToJSONKey`)
+> instances for [`Network.URI.URI`][network-uri] directly. This
+> package is redundant, and its orphan instances *conflict* with
+> aeson's on aeson `>= 2.2` — the two cannot be imported together.
+> Drop the `network-uri-json` dependency and use aeson's built-in
+> instances.
+>
+> One behavioural difference if you relied on it: this package decoded
+> with `parseURIReference` (accepts relative references such as
+> `/path`), whereas aeson decodes with `parseURI` (absolute URIs
+> only). The encoding (`uriToString`) is identical.
+
 [FromJSON] and [ToJSON] Instances for [Network.URI][network-uri]
 
 # Getting Started


### PR DESCRIPTION
## Summary

aeson 2.2.0.0 (2023) ships `FromJSON`/`ToJSON` — plus the `FromJSONKey`/`ToJSONKey` variants this package never had — for `Network.URI.URI` directly. That moots this package's reason for existing, and worse, its orphan instances *conflict* with aeson's on aeson `>= 2.2`: the two can no longer be imported together. This marks the README as deprecated and points readers at aeson, ahead of flagging the package `deprecated` on Hackage and archiving the repo.

## Gotchas

- One behavioural difference, not a pure drop-in: this package decoded with `parseURIReference` (accepts relative references like `/path`), whereas aeson uses `parseURI` (absolute URIs only). Encoding (`uriToString`) is byte-identical. Anyone relying on relative-reference decoding needs to handle it themselves — called out in the notice.
- README-only. The Hackage `deprecated` flag (in favour of `aeson`) and the GitHub archive are separate manual steps and are intentionally not in this PR.

## Verification

Docs change only — no library code touched. The notice renders as a blockquote at the top of the README; existing `cabal build` / `cabal test` are unaffected.
